### PR TITLE
bad filename for README

### DIFF
--- a/ike/payloads.py
+++ b/ike/payloads.py
@@ -45,6 +45,7 @@ class Type(IntEnum):
     Nr = 40
     Notify = 41
     Delete = 42
+    Vendor = 43
     TSi = 44
     TSr = 45
     SK = 46
@@ -54,6 +55,7 @@ class Type(IntEnum):
     IDg = 50
     GSA = 51
     KD = 52
+    Fragment = 132
 
     def __repr__(self, *args, **kwargs):
         return '<{}: {}>'.format(self.name, self.value)
@@ -192,6 +194,26 @@ class Nonce(_IkePayload):
             self.length = const.PAYLOAD_HEADER.size + len(self._data)
 
 
+class Vendor(_IkePayload):
+    """
+    `Nonce Payload <https://tools.ietf.org/html/rfc5996#section-3.12>`_
+    """
+    def parse(self, data):
+        self._data = data[const.PAYLOAD_HEADER.size:self.length]
+
+    def __init__(self, data=None, next_payload=Type.no_next_payload, critical=False,
+                 vendor=None):
+        super(Vendor, self).__init__(data, next_payload, critical)
+        if data is not None:
+            self.parse(data)
+        else:
+            if vendor:
+                self._data = vendor
+            else:
+                self._data = os.urandom(32)
+            self.length = const.PAYLOAD_HEADER.size + len(self._data)
+
+
 class Notify(_IkePayload):
     """
     `Notify Payload <https://tools.ietf.org/html/rfc5996#section-3.10>`_
@@ -225,6 +247,24 @@ class Notify(_IkePayload):
                 self.spi_size, self.length)
         else:
             return '<Notify payload {0!r} [{1}]>'.format(self.message_type, self.length)
+
+
+class Fragment(_IkePayload):
+    """
+    `Fragment Payload`
+    """
+    def parse(self, data):
+        self._data = data[const.PAYLOAD_HEADER.size:self.length]
+
+    def __init__(self, data=None, next_payload=Type.no_next_payload, critical=False,
+                 fragment=None):
+        super(Fragment, self).__init__(data, next_payload, critical)
+        if data is not None:
+            self.parse(data)
+        else:
+            if fragment:
+                self._data = fragment
+                self.length = const.PAYLOAD_HEADER.size + len(self._data)
 
 
 class _TS(_IkePayload):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from ike import __version__
 
 def readme():
-    with open("README.rst") as f:
+    with open("README.md") as f:
         return f.read()
 
 


### PR DESCRIPTION
was barfing setup.py

```
/usr/src/app/ike # python3 setup.py
Traceback (most recent call last):
  File "setup.py", line 14, in <module>
    long_description=readme(),
  File "setup.py", line 7, in readme
    with open("README.rst") as f:
```

this fixes it:

```
/usr/src/app/ike # python3 setup.py  install
running install
running bdist_egg
running egg_info
creating ike.egg-info
writing ike.egg-info/PKG-INFO
writing dependency_links to ike.egg-info/dependency_links.txt
writing top-level names to ike.egg-info/top_level.txt
writing manifest file 'ike.egg-info/SOURCES.txt'
reading manifest file 'ike.egg-info/SOURCES.txt'
writing manifest file 'ike.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
creating build
creating build/lib
creating build/lib/ike
copying ike/__init__.py -> build/lib/ike
copying ike/protocol.py -> build/lib/ike
copying ike/payloads.py -> build/lib/ike
copying ike/proposal.py -> build/lib/ike
copying ike/const.py -> build/lib/ike
copying ike/initiator.py -> build/lib/ike
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/ike
copying build/lib/ike/__init__.py -> build/bdist.linux-x86_64/egg/ike
copying build/lib/ike/protocol.py -> build/bdist.linux-x86_64/egg/ike
copying build/lib/ike/payloads.py -> build/bdist.linux-x86_64/egg/ike
copying build/lib/ike/proposal.py -> build/bdist.linux-x86_64/egg/ike
copying build/lib/ike/const.py -> build/bdist.linux-x86_64/egg/ike
copying build/lib/ike/initiator.py -> build/bdist.linux-x86_64/egg/ike
byte-compiling build/bdist.linux-x86_64/egg/ike/__init__.py to __init__.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/ike/protocol.py to protocol.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/ike/payloads.py to payloads.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/ike/proposal.py to proposal.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/ike/const.py to const.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/ike/initiator.py to initiator.cpython-36.pyc
creating build/bdist.linux-x86_64/egg/EGG-INFO
copying ike.egg-info/PKG-INFO -> build/bdist.linux-x86_64/egg/EGG-INFO
copying ike.egg-info/SOURCES.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying ike.egg-info/dependency_links.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying ike.egg-info/top_level.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
ike.__pycache__.initiator.cpython-36: module references __file__
creating dist
creating 'dist/ike-0.1.0-py3.6.egg' and adding 'build/bdist.linux-x86_64/egg' to it
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing ike-0.1.0-py3.6.egg
creating /usr/local/lib/python3.6/site-packages/ike-0.1.0-py3.6.egg
Extracting ike-0.1.0-py3.6.egg to /usr/local/lib/python3.6/site-packages
Adding ike 0.1.0 to easy-install.pth file

Installed /usr/local/lib/python3.6/site-packages/ike-0.1.0-py3.6.egg
Processing dependencies for ike==0.1.0
Finished processing dependencies for ike==0.1.0```